### PR TITLE
Rename package to GoogleHashCode2014

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,6 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest
-            using HashCode2014
-            DocMeta.setdocmeta!(HashCode2014, :DocTestSetup, :(using HashCode2014); recursive=true)
-            doctest(HashCode2014)'
+            using GoogleHashCode2014
+            DocMeta.setdocmeta!(GoogleHashCode2014, :DocTestSetup, :(using GoogleHashCode2014); recursive=true)
+            doctest(GoogleHashCode2014)'

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
-[HashCode2014Data]
-git-tree-sha1 = "483986993af6706dd6e7d4c33d9a2aa71093ec61"
+[GoogleHashCode2014Data]
+git-tree-sha1 = "ea9ff7494acba11a3681972b1030bd1b0cb2b6ae"
 
-    [[HashCode2014Data.download]]
-    sha256 = "422078be54e637e36201d75831a8522cf1ba101c5b796d4ec0f45ffac92b9dc2"
-    url = "https://github.com/gdalle/HashCode2014Data/archive/refs/tags/v0.1.tar.gz"
+    [[GoogleHashCode2014Data.download]]
+    sha256 = "623bbe2ef2f6ee298665c0e5a5cde31a54570fc4f42e33341323a4dacf50da02"
+    url = "https://github.com/gdalle/GoogleHashCode2014Data/archive/refs/tags/v0.1.tar.gz"

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,8 +1,8 @@
-@misc{HashCode2014.jl,
+@misc{GoogleHashCode2014.jl,
 	author  = {Guillaume Dalle},
-	title   = {HashCode2014.jl},
-	url     = {https://github.com/gdalle/HashCode2014.jl},
-	version = {v0.1.1},
-	year    = {2023},
-	month   = {10}
+	title   = {GoogleHashCode2014.jl},
+	url     = {https://github.com/gdalle/GoogleHashCode2014.jl},
+	version = {v0.2.0},
+	year    = {2024},
+	month   = {8}
 }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
-name = "HashCode2014"
+name = "GoogleHashCode2014"
 uuid = "7bbed249-721d-42ac-b1f6-7cf884be0fbe"
 authors = ["Guillaume Dalle"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -11,11 +11,18 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extensions]
-HashCode2014PythonCallExt = "PythonCall"
+GoogleHashCode2014PythonCallExt = "PythonCall"
 
 [compat]
-PythonCall = "0.9"
-julia = "1.9"
+Aqua = "0.8.7"
+Artifacts = "1.10"
+Documenter = "1.6"
+JET = "0.9.8"
+JuliaFormatter = "1.0.60"
+PythonCall = "0.9.23"
+Random = "1.10"
+Test = "1.10"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# HashCode2014.jl
+# GoogleHashCode2014.jl
 
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://gdalle.github.io/HashCode2014.jl/dev/)
-[![Build Status](https://github.com/gdalle/HashCode2014.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/gdalle/HashCode2014.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/gdalle/HashCode2014.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/gdalle/HashCode2014.jl)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://gdalle.github.io/GoogleHashCode2014.jl/dev/)
+[![Build Status](https://github.com/gdalle/GoogleHashCode2014.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/gdalle/GoogleHashCode2014.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/gdalle/GoogleHashCode2014.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/gdalle/GoogleHashCode2014.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
 Lightweight package designed to interact with the data of the 2014 Google Hash Code.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-HashCode2014 = "7bbed249-721d-42ac-b1f6-7cf884be0fbe"
+GoogleHashCode2014 = "7bbed249-721d-42ac-b1f6-7cf884be0fbe"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,9 @@
-using HashCode2014
+using GoogleHashCode2014
 using Documenter
 
-DocMeta.setdocmeta!(HashCode2014, :DocTestSetup, :(using HashCode2014); recursive=true)
+DocMeta.setdocmeta!(
+    GoogleHashCode2014, :DocTestSetup, :(using GoogleHashCode2014); recursive=true
+)
 
 cp(
     joinpath(dirname(@__DIR__), "README.md"),
@@ -10,14 +12,11 @@ cp(
 )
 
 makedocs(;
-    modules=[HashCode2014],
+    modules=[GoogleHashCode2014],
     authors="Guillaume Dalle",
-    sitename="HashCode2014.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://gdalle.github.io/HashCode2014.jl",
-    ),
+    sitename="GoogleHashCode2014.jl",
+    format=Documenter.HTML(),
     pages=["Home" => "index.md", "Tutorial" => "tutorial.md", "API reference" => "api.md"],
 )
 
-deploydocs(; repo="github.com/gdalle/HashCode2014.jl", devbranch="main", push_preview=true)
+deploydocs(; repo="github.com/gdalle/GoogleHashCode2014.jl", devbranch="main")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,7 +3,7 @@
 ## Docstrings
 
 ```@autodocs
-Modules = [HashCode2014]
+Modules = [GoogleHashCode2014]
 ```
 
 ## Index

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -7,7 +7,7 @@ You need to install it from the GitHub repo with
 
 ```julia
 using Pkg
-Pkg.add(url="https://github.com/gdalle/HashCode2014.jl")
+Pkg.add(url="https://github.com/gdalle/GoogleHashCode2014.jl")
 ```
 
 ## Instance and solutions
@@ -16,7 +16,7 @@ A problem instance is encoded in an object of type [`City`](@ref).
 You can create one for the setting of the challenge (the streets of Paris) as follows:
 
 ```jldoctest tuto
-julia> using HashCode2014
+julia> using GoogleHashCode2014
 
 julia> city = read_city()
 City with 11348 junctions and 17958 streets, where 8 cars must start from junction 4517 and travel for at most 54000 seconds

--- a/ext/GoogleHashCode2014PythonCallExt.jl
+++ b/ext/GoogleHashCode2014PythonCallExt.jl
@@ -1,9 +1,9 @@
-module HashCode2014PythonCallExt
+module GoogleHashCode2014PythonCallExt
 
-using HashCode2014
+using GoogleHashCode2014
 using PythonCall
 
-function HashCode2014.plot_streets(
+function GoogleHashCode2014.plot_streets(
     city::City, solution::Union{Solution,Nothing}=nothing; path=nothing
 )
     folium = pyimport("folium")

--- a/src/GoogleHashCode2014.jl
+++ b/src/GoogleHashCode2014.jl
@@ -1,9 +1,9 @@
 """
-    HashCode2014
+    GoogleHashCode2014
 
 Lightweight package designed to interact with the data of the 2014 Google Hash Code.
 """
-module HashCode2014
+module GoogleHashCode2014
 
 using Artifacts: @artifact_str
 using Random: AbstractRNG, default_rng

--- a/src/city.jl
+++ b/src/city.jl
@@ -77,7 +77,9 @@ Read and parse a [`City`](@ref) from a file located at `path`.
 The default path is an artifact containing the official challenge data from <https://storage.googleapis.com/coding-competitions.appspot.com/HC/2014/paris_54000.txt>.
 """
 function read_city(
-    path=joinpath(artifact"HashCode2014Data", "HashCode2014Data-0.1", "paris_54000.txt")
+    path=joinpath(
+        artifact"GoogleHashCode2014Data", "GoogleHashCode2014Data-0.1", "paris_54000.txt"
+    ),
 )
     city_string = open(path, "r") do file
         read(file, String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,28 +1,30 @@
 using Aqua
 using Documenter
-using HashCode2014
+using GoogleHashCode2014
 using JET
 using JuliaFormatter
 using PythonCall
 using Test
 
-DocMeta.setdocmeta!(HashCode2014, :DocTestSetup, :(using HashCode2014); recursive=true)
+DocMeta.setdocmeta!(
+    GoogleHashCode2014, :DocTestSetup, :(using GoogleHashCode2014); recursive=true
+)
 
-@testset verbose = true "HashCode2014.jl" begin
+@testset verbose = true "GoogleHashCode2014.jl" begin
     @testset "Code quality (Aqua.jl)" begin
-        Aqua.test_all(HashCode2014; ambiguities=false)
+        Aqua.test_all(GoogleHashCode2014; ambiguities=false)
     end
 
     @testset "Code formatting (JuliaFormatter.jl)" begin
-        @test format(HashCode2014; verbose=false, overwrite=false)
+        @test format(GoogleHashCode2014; verbose=false, overwrite=false)
     end
 
     @testset "Code linting (JET.jl)" begin
-        JET.test_package(HashCode2014; target_defined_modules=true)
+        JET.test_package(GoogleHashCode2014; target_defined_modules=true)
     end
 
     @testset "Doctests (Documenter.jl)" begin
-        doctest(HashCode2014)
+        doctest(GoogleHashCode2014)
     end
 
     @testset "Small instance" begin


### PR DESCRIPTION
- Rename package to GoogleHashCode2014 (all satellite packages have also been renamed)
- Bump version to v0.2.0
- Update artifacts and docs